### PR TITLE
chore(renovate): ignore node engines

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -1,6 +1,15 @@
 {
-	"$schema": "https://docs.renovatebot.com/renovate-schema.json",
-	"extends": ["config:base", "schedule:monthly", "group:allNonMajor"],
-	"rangeStrategy": "bump",
-	"packageRules": [{ "depTypeList": ["peerDependencies"], "enabled": false }]
+  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "extends": ["config:base", "schedule:monthly", "group:allNonMajor"],
+  "rangeStrategy": "bump",
+  "packageRules": [
+    { "depTypeList": ["peerDependencies"], "enabled": false },
+    {
+      "description": "Ignore node engines",
+      "matchPackageNames": ["node"],
+      "matchManagers": ["npm"],
+      "matchDepTypes": ["engines"],
+      "enabled": false
+    }
+  ]
 }


### PR DESCRIPTION
Renovate should not bump `engines.node`.
https://github.com/renovatebot/renovate/discussions/13521