### PR TITLE
chore: upgrade TypeScript to 6.0.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,7 +24,9 @@
     "test": "rstest",
     "bump": "npx bumpp"
   },
-  "files": ["dist"],
+  "files": [
+    "dist"
+  ],
   "simple-git-hooks": {
     "pre-commit": "npx nano-staged"
   },
@@ -41,7 +43,7 @@
     "@types/node": "^24.10.1",
     "nano-staged": "^0.9.0",
     "simple-git-hooks": "^2.13.1",
-    "typescript": "5.9.3"
+    "typescript": "^6.0.2"
   },
   "packageManager": "pnpm@10.24.0",
   "publishConfig": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -13,7 +13,7 @@ importers:
         version: 1.9.4
       '@rslib/core':
         specifier: ^0.18.2
-        version: 0.18.2(typescript@5.9.3)
+        version: 0.18.2(typescript@6.0.2)
       '@rspack/core':
         specifier: ^1.6.5
         version: 1.6.5(@swc/helpers@0.5.17)
@@ -30,8 +30,8 @@ importers:
         specifier: ^2.13.1
         version: 2.13.1
       typescript:
-        specifier: 5.9.3
-        version: 5.9.3
+        specifier: ^6.0.2
+        version: 6.0.2
 
 packages:
 
@@ -423,8 +423,8 @@ packages:
   tslib@2.8.1:
     resolution: {integrity: sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==}
 
-  typescript@5.9.3:
-    resolution: {integrity: sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==}
+  typescript@6.0.2:
+    resolution: {integrity: sha512-bGdAIrZ0wiGDo5l8c++HWtbaNCWTS4UTv7RaTH/ThVIgjkveJt83m74bBHMJkuCbslY8ixgLBVZJIOiQlQTjfQ==}
     engines: {node: '>=14.17'}
     hasBin: true
 
@@ -596,12 +596,12 @@ snapshots:
       core-js: 3.47.0
       jiti: 2.6.1
 
-  '@rslib/core@0.18.2(typescript@5.9.3)':
+  '@rslib/core@0.18.2(typescript@6.0.2)':
     dependencies:
       '@rsbuild/core': 1.6.10
-      rsbuild-plugin-dts: 0.18.2(@rsbuild/core@1.6.10)(typescript@5.9.3)
+      rsbuild-plugin-dts: 0.18.2(@rsbuild/core@1.6.10)(typescript@6.0.2)
     optionalDependencies:
-      typescript: 5.9.3
+      typescript: 6.0.2
     transitivePeerDependencies:
       - '@typescript/native-preview'
 
@@ -755,12 +755,12 @@ snapshots:
 
   picocolors@1.0.1: {}
 
-  rsbuild-plugin-dts@0.18.2(@rsbuild/core@1.6.10)(typescript@5.9.3):
+  rsbuild-plugin-dts@0.18.2(@rsbuild/core@1.6.10)(typescript@6.0.2):
     dependencies:
       '@ast-grep/napi': 0.37.0
       '@rsbuild/core': 1.6.10
     optionalDependencies:
-      typescript: 5.9.3
+      typescript: 6.0.2
 
   simple-git-hooks@2.13.1: {}
 
@@ -768,6 +768,6 @@ snapshots:
 
   tslib@2.8.1: {}
 
-  typescript@5.9.3: {}
+  typescript@6.0.2: {}
 
   undici-types@7.16.0: {}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,25 +1,15 @@
 {
   "compilerOptions": {
-    "module": "NodeNext",
-    "moduleResolution": "NodeNext",
-    "target": "ES2021",
-    "esModuleInterop": true,
+    "rootDir": "./src",
+    "outDir": "./dist",
+    "target": "ES2023",
+    "types": ["node"],
+    "lib": ["DOM", "ESNext"],
     "declaration": true,
     "isolatedModules": true,
-    "sourceMap": true,
-    "declarationMap": true,
-    "composite": true,
-    "forceConsistentCasingInFileNames": true,
-    "allowJs": true,
-    "checkJs": true,
-    "strict": true,
     "skipLibCheck": true,
-    "noUnusedLocals": true,
-    "outDir": "dist",
-    "rootDir": "src"
-  },
-  "ts-node": {
-    "transpileOnly": true
+    "module": "nodenext",
+    "moduleResolution": "nodenext"
   },
   "include": ["src"]
 }


### PR DESCRIPTION
## Summary

- Upgrade TypeScript to ^6.0.2.
- Replace the root `tsconfig.json` with the shared NodeNext configuration.
- Validate the change with `pnpm build` and `pnpm test`.

## Related Links

- https://github.com/microsoft/TypeScript/releases/tag/v6.0.2