### PR TITLE
fix: export package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,7 +13,8 @@
       "types": "./dist/index.d.ts",
       "require": "./dist/index.cjs",
       "import": "./dist/index.js"
-    }
+    },
+    "./package.json": "./package.json"
   },
   "scripts": {
     "build": "rslib",

--- a/test/PackageExports.test.js
+++ b/test/PackageExports.test.js
@@ -1,0 +1,9 @@
+"use strict";
+
+describe("package exports", () => {
+	it("should export package.json", () => {
+		expect(require("@rspack/lite-tapable/package.json")).toMatchObject({
+			name: "@rspack/lite-tapable"
+		});
+	});
+});


### PR DESCRIPTION
## Summary

`@rspack/lite-tapable/package.json` cannot currently be resolved because the package export map only exposes the root entry. This PR exports `./package.json` and adds regression coverage for package subpath resolution.

## Related Links

- https://github.com/web-infra-dev/rsdoctor/pull/1855