### PR TITLE
feat: export Tap type

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -40,7 +40,7 @@ type FullTap = Tap & {
   fn: AnyFunction;
 };
 
-type Tap = TapOptions & {
+export type Tap = TapOptions & {
   name: string;
 };
 


### PR DESCRIPTION
This PR exposes the existing `Tap` type so consumers can type reusable tap option objects without deriving it from the `Options` union. The change is type-only and does not affect runtime exports.